### PR TITLE
fix to take tests & create tests for filter

### DIFF
--- a/framework/data/ActiveDataProvider.php
+++ b/framework/data/ActiveDataProvider.php
@@ -113,7 +113,12 @@ class ActiveDataProvider extends BaseDataProvider
         }
         
         if (($filter = $this->getFilter()) !== false) {
-            foreach ($filter->getConditions($this->query->modelClass) as $condition) {
+            if (!empty($this->query->modelClass)) {
+                $modelClass = $this->query->modelClass;
+            } else {
+                $modelClass = null;
+            }
+            foreach ($filter->getConditions($modelClass) as $condition) {
                 $query->andWhere($condition);
             }
         }

--- a/framework/data/Filter.php
+++ b/framework/data/Filter.php
@@ -55,23 +55,26 @@ class Filter extends Object
     ];
 
     /**
-     * @param string $modelClass
+     * @param string|null $modelClass
      * @return array
      * @throws NotAcceptableHttpException
      */
-    public function getConditions($modelClass)
+    public function getConditions($modelClass = null)
     {
         $filter = $this->getRequestFilter();
         $conditions = [];
 
         if (!empty($filter)) {
-            /** @var $model ActiveRecord */
-            $model = new $modelClass;
+
+            if(!is_null($modelClass)) {
+                /** @var ActiveRecord $model */
+                $model = Yii::createObject($modelClass);
+            }
 
             foreach ($filter as $field => $value) {
                 list($operator, $field) = $this->prepareField($field);
 
-                if (!$this->isAcceptableField($field) || !$model->hasAttribute($field)) {
+                if (!$this->isAcceptableField($field) || (!empty($model) && $model->hasAttribute($field))) {
                     throw new NotAcceptableHttpException('Filter by field "' . $field . '" unsupported.');
                 }
                 

--- a/tests/framework/data/FilterTest.php
+++ b/tests/framework/data/FilterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace yiiunit\framework\data;
+
+use yii\data\Filter;
+use yiiunit\TestCase;
+
+class FilterTest extends TestCase
+{
+    public function testBuildCondition()
+    {
+        $field_name   = 'some_field';
+        $value_string = 'some_string';
+        $value_int    = 8;
+        $value_array  = [15, 16];
+        $filter       = new Filter();
+
+        $condition = $filter->buildCondition('>=', $field_name, $value_int);
+        $this->assertEquals($condition, ['>=', $field_name, $value_int]);
+        $condition = $filter->buildCondition('<=', $field_name, $value_int);
+        $this->assertEquals($condition, ['<=', $field_name, $value_int]);
+        $condition = $filter->buildCondition('>', $field_name, $value_int);
+        $this->assertEquals($condition, ['>', $field_name, $value_int]);
+        $condition = $filter->buildCondition('<', $field_name, $value_int);
+        $this->assertEquals($condition, ['<', $field_name, $value_int]);
+        $condition = $filter->buildCondition('!=', $field_name, $value_int);
+        $this->assertEquals($condition, ['NOT', [$field_name => $value_int]]);
+        $condition = $filter->buildCondition('!=', $field_name, $value_array);
+        $this->assertEquals($condition, ['NOT IN', $field_name, $value_array]);
+        $condition = $filter->buildCondition(null, $field_name, $value_int);
+        $this->assertEquals($condition, [$field_name => $value_int]);
+        $condition = $filter->buildCondition('like', $field_name, $value_string);
+        $this->assertEquals($condition, ['like', $field_name, $value_string, false]);
+    }
+}


### PR DESCRIPTION
## Fix to take tests
* check exists property `modelClass` in method `ActiveDataProvider::prepareModels`. If property doesn't exists use null as a parameter of `Filter::getCondition`
* in `Filter::getCondition` if `$modelClass` is null not check `$model->hasAttribute`

## Create tests for `Filter`
Designed for `Filter` *tests* checks all possible *filter operators* 